### PR TITLE
Avoid call Twitch API from development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env.*.local

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Default from "./components/Default";
 import Info from "./components/Info";
 
 import Settings from "./components/Settings";
-import { channelState } from "./states/channel";
+import { Channel, channelState } from "./states/channel";
 import { settingsState } from "./states/settings";
 
 const App: FC = () => {
@@ -16,22 +16,28 @@ const App: FC = () => {
   const [settings, setSettings] = useRecoilState(settingsState);
 
   useEffect(() => {
-    Twitch.ext.onAuthorized((auth) => {
-      const { channelId } = auth;
+    if (import.meta.env.PROD) {
+      Twitch.ext.onAuthorized(({ channelId }) => {
+        initializeChannelState(channelId);
+      });
+    } else {
+      const channelIdForDevelopment =
+        import.meta.env.VITE_CHANNEL_ID ?? "195641865";
+      initializeChannelState(channelIdForDevelopment);
+    }
 
-      (async () => {
-        const response = await fetch(
-          `https://api.wakscord.xyz/extension/${channelId}`
-        );
+    async function initializeChannelState(channelId: string) {
+      const response = await fetch(
+        `https://api.wakscord.xyz/extension/${channelId}`
+      );
 
-        const data = await response.json();
+      const data = (await response.json()) as Channel;
 
-        setChannel({
-          twitchId: channelId,
-          ...data,
-        });
-      })();
-    });
+      setChannel({
+        twitchId: channelId,
+        ...data,
+      });
+    }
   }, []);
 
   if (!channel || !channel.id) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ const App: FC = () => {
         `https://api.wakscord.xyz/extension/${channelId}`
       );
 
-      const data = (await response.json()) as Channel;
+      const data = (await response.json()) as Omit<Channel, "twitchId">;
 
       setChannel({
         twitchId: channelId,


### PR DESCRIPTION
Vite 개발 모드 및 환경 변수가 담긴 `import.meta.env` 개체 값을 통해 Twitch API 호출을 제어하도록 구성했습니다.

프로덕션 빌드에서는 Twitch API 호출을 통해 얻은 채널 ID를 바탕으로 데이터를 패칭하고 
개발 모드에서는 `VITE_CHANNEL_ID` 값 또는 비챤님 채널 ID 정보로 패칭할 데이터를 고정했습니다.

참조: https://vitejs.dev/guide/env-and-mode.html

개발 환경에서 비챤님 말고 세구님 채널 데이터를 보여주고 싶다! 하면 아래와 같이 `.env.development.local` 파일을 만드셔서 바꾸어주시면 됩니다.

```
# .env.development.local
VITE_CHANNEL_ID=707328484
```