### PR TITLE
설정창 닫힐 때 배경 요소 클릭 가능하도록 설정

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -129,6 +129,7 @@ const Container = styled.div<{ isOpen: boolean }>`
 
   visibility: ${(props) => (props.isOpen ? "visible" : "hidden")};
   transition: visibility 0.2s ease-in-out;
+  pointer-events: ${(props) => (props.isOpen ? "auto" : "none")};
 
   animation: ${(props) => (props.isOpen ? fadeinAnimation : fadeoutAnimation)}
     0.2s ease-in-out;


### PR DESCRIPTION
## Overview
설정 창이 닫히면서 animation이 종료되고 component가 제거될 때까지는 메시지 링크와 같은 배경 요소를 클릭할 수 없는데, 이러한 UX적 문제점을 수정하고자 했습니다.