### PR TITLE
설정창 성능 이슈 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,19 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 
-import { useRecoilState } from 'recoil';
-import { ReactComponent as SettingsIconSVG } from './assets/settings.svg';
 import Chats from './components/Chats';
 import Default from './components/Default';
 import Error from './components/Error';
 import Info from './components/Info';
 
 import Settings from './components/Settings';
-import { settingsState } from './states/settings';
 import { useChannelState } from './hooks/ChannelStates';
 import { useChannelId } from './hooks/ChannelId';
+import { SettingsIcon } from './components/SettingsIcon';
 
 const App: FC = () => {
   const channelId = useChannelId();
   const { channel, error, refresh } = useChannelState(channelId);
-  const [settings, setSettings] = useRecoilState(settingsState);
 
   if (error) {
     return <Error onRefresh={refresh} />;
@@ -32,16 +29,7 @@ const App: FC = () => {
 
       <Container>
         <SettingButtonContainer>
-          <SettingsIcon
-            width={20}
-            height={20}
-            onClick={() => {
-              setSettings({
-                ...settings,
-                isOpen: true,
-              });
-            }}
-          />
+          <SettingsIcon />
         </SettingButtonContainer>
 
         <ChatsConainer>
@@ -65,10 +53,6 @@ const SettingButtonContainer = styled.div`
   padding: 5px;
   box-sizing: border-box;
   height: 30px;
-`;
-
-const SettingsIcon = styled(SettingsIconSVG)`
-  cursor: pointer;
 `;
 
 const Container = styled.div`

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,7 +6,7 @@ import { Controller, useForm } from "react-hook-form";
 import { ReactComponent as CloseIconSVG } from "../assets/close.svg";
 import { streamerNames } from "../constants";
 import { Channel } from "../states/channel";
-import { Settings, settingsState } from "../states/settings";
+import { Settings, settingsOpenState, settingsState } from "../states/settings";
 import Slider from "./discord/Slider";
 
 interface SettingsProps {
@@ -15,8 +15,8 @@ interface SettingsProps {
 type FormFields = Omit<Settings, "isOpen">;
 
 const Settings: FC<SettingsProps> = ({ channel }) => {
-  const [{ isOpen, ...defaultValues }, setSettings] =
-    useRecoilState(settingsState);
+  const [isOpen, setIsOpen] = useRecoilState(settingsOpenState);
+  const [defaultValues, setSettings] = useRecoilState(settingsState);
 
   const { control, watch, handleSubmit } = useForm<FormFields>({
     defaultValues,
@@ -42,12 +42,7 @@ const Settings: FC<SettingsProps> = ({ channel }) => {
         <CloseIcon
           width={20}
           height={20}
-          onClick={() => {
-            setSettings((settings) => ({
-              ...settings,
-              isOpen: false,
-            }));
-          }}
+          onClick={() => setIsOpen(false)}
         />
       </CloseButtonContainer>
       <InnerContainer>

--- a/src/components/SettingsIcon.tsx
+++ b/src/components/SettingsIcon.tsx
@@ -1,0 +1,14 @@
+import { useSetRecoilState } from 'recoil'
+import { ReactComponent as SettingsIconSVG } from '../assets/settings.svg'
+import styled from 'styled-components'
+import { settingsOpenState } from '../states/settings'
+
+export const SettingsIcon = () => {
+  const setter = useSetRecoilState(settingsOpenState)
+
+  return <Icon width={20} height={20} onClick={() => setter(true)} />
+}
+
+const Icon = styled(SettingsIconSVG)`
+  cursor: pointer;
+`

--- a/src/states/settings.ts
+++ b/src/states/settings.ts
@@ -2,7 +2,6 @@ import { atom } from "recoil";
 import { streamerNames } from "../constants";
 
 export interface Settings {
-  isOpen: boolean;
   autoRefresh: boolean;
   wakzoos: Wakzoos;
   notify: boolean;
@@ -34,10 +33,14 @@ const initialWakzoosValue = Object.fromEntries(
 export const settingsState = atom<Settings>({
   key: "settingsState",
   default: {
-    isOpen: false,
     autoRefresh: localStorage.getItem("autoRefresh") === "true",
     wakzoos: wakzoos ? (JSON.parse(wakzoos) as Wakzoos) : initialWakzoosValue,
     notify: notify ? notify === "true" : true,
     authors: authors ? (JSON.parse(authors) as Authors) : initialAuthorsValue,
   },
+});
+
+export const settingsOpenState = atom<boolean>({
+  key: "settingsOpenState",
+  default: false,
 });


### PR DESCRIPTION
기존의 경우 설정 값이 변경되면 앱 전체가 다시 refresh 되면서 설정 토글시마다 버벅거리는 현상이 발생하였는데, 이 PR은 App에서 settings의 상태에 관여하지 않고 버튼이 해당 역할을 분담하게 하고 settings에서 `isOpen`을 분리하면서 오로지 설정 창 컴포넌트만 영향을 받도록 수정했습니다.

## Before
<img width="1491" alt="Screenshot 2023-05-28 at 11 26 43 AM" src="https://github.com/wakscord/extension/assets/32066651/24dc8182-a747-4c2b-834f-6dc78d7f9a91">
<img width="1793" alt="Screenshot 2023-05-28 at 11 27 51 AM" src="https://github.com/wakscord/extension/assets/32066651/d654c943-caaa-4557-849f-5273612b4557">

## After
<img width="1491" alt="Screenshot 2023-05-28 at 11 34 08 AM" src="https://github.com/wakscord/extension/assets/32066651/bb972b00-2b01-4dab-81db-28dd230672f2">
<img width="1793" alt="Screenshot 2023-05-28 at 11 37 48 AM" src="https://github.com/wakscord/extension/assets/32066651/ee8a0fa7-a6a7-4ce5-a229-b8599faa74d7">


