### PR TITLE
fix(discord): convert rem to px

### DIFF
--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -67,12 +67,12 @@ const Texts = styled.div<{ color: string }>`
 `;
 
 const Name = styled.span`
-  font-size: 1.5rem;
+  font-size: 24px;
   font-weight: 800;
 `;
 
 const Link = styled.a`
-  font-size: 0.9rem;
+  font-size: 14.4px;
   opacity: 0.9;
 
   transition: opacity 0.2s ease-in-out;

--- a/src/components/discord/Badge.tsx
+++ b/src/components/discord/Badge.tsx
@@ -10,17 +10,17 @@ const Badge: FC<BadgeProps> = ({ children }) => {
 };
 
 const Container = styled.span`
-  margin-right: 0.25rem;
+  margin-right: 4px;
 
-  font-size: 0.7rem;
+  font-size: 11.2px;
 
-  height: 0.9rem;
-  line-height: 0.9rem;
-  padding: 0 0.25rem;
-  border-radius: 0.1875rem;
+  height: 14.4px;
+  line-height: 14.4px;
+  padding: 0 4px;
+  border-radius: 3px;
 
   box-sizing: border-box;
-  margin-bottom: 0.1rem;
+  margin-bottom: 1.6px;
 
   background-color: #5865f2;
 `;

--- a/src/components/discord/Embed.tsx
+++ b/src/components/discord/Embed.tsx
@@ -67,7 +67,7 @@ const Embed: FC<EmbedProp> = ({ embed }) => {
 const Container = styled.div<{ borderColor?: number }>`
   margin-top: 5px;
   max-width: 432px;
-  padding: 0.5rem 1rem 0.5rem 0.75rem;
+  padding: 8px 16px 8px 12px;
 
   background-color: #2f3136;
   border-radius: 4px;
@@ -81,21 +81,21 @@ const Container = styled.div<{ borderColor?: number }>`
 `;
 
 const Author = styled.div`
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 600;
   color: #b9bbbe;
 `;
 
 const Title = styled.span`
   display: block;
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 700;
   margin: 7px 0;
 `;
 
 const UrlTitle = styled.a`
   display: block;
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 700;
   color: #00aff4;
   margin: 7px 0;
@@ -111,7 +111,7 @@ const UrlTitle = styled.a`
 
 const Description = styled.span`
   display: block;
-  font-size: 0.875rem;
+  font-size: 14px;
   white-space: pre-wrap;
   font-weight: 400;
   margin-bottom: 2px;
@@ -132,7 +132,7 @@ const Field = styled.div<{ inline: boolean }>`
 `;
 
 const FieldName = styled.span`
-  font-size: 0.875rem;
+  font-size: 14px;
   color: #dcddde;
 
   span {
@@ -141,7 +141,7 @@ const FieldName = styled.span`
 `;
 
 const FieldValue = styled.span`
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: 400;
   color: #dcddde;
   white-space: pre-wrap;
@@ -156,7 +156,7 @@ const Image = styled.img`
 `;
 
 const Timestamp = styled.span`
-  font-size: 0.75rem;
+  font-size: 12px;
 `;
 
 export default Embed;

--- a/src/components/discord/Message.tsx
+++ b/src/components/discord/Message.tsx
@@ -91,7 +91,7 @@ const Container = styled.div<{ isCompact: boolean }>`
   ${(props) =>
     !props.isCompact &&
     css`
-      margin-top: 1rem;
+      margin-top: 16px;
       padding: 3px 0 3px 10px;
     `}
 
@@ -106,10 +106,10 @@ const HoverInfo = styled.div`
   left: -7.5px;
 
   width: 73px;
-  height: 1.4rem;
-  line-height: 1.4rem;
+  height: 22.4px;
+  line-height: 22.4px;
   text-align: center;
-  font-size: 0.7rem;
+  font-size: 11.2px;
   color: #b9bbbe;
 
   opacity: 0;
@@ -141,7 +141,7 @@ const Header = styled.div`
 `;
 
 const Title = styled.div`
-  margin-right: 0.25rem;
+  margin-right: 4px;
 
   display: flex;
   align-items: center;
@@ -149,7 +149,7 @@ const Title = styled.div`
 `;
 
 const Username = styled.span`
-  margin-right: 0.25rem;
+  margin-right: 4px;
 
   color: white;
   font-weight: 500;
@@ -157,7 +157,7 @@ const Username = styled.span`
 
 const Info = styled.span`
   color: #a3a6aa;
-  font-size: 0.8rem;
+  font-size: 12.8px;
 `;
 
 const ContentContainer = styled.div`


### PR DESCRIPTION
## 확인하셨나요?

- [x] Prettier 를 사용해서 코드 포멧팅과 함께 커밋을 하셨나요? 저장 시 코드 포멧팅을 자동으로 해주는 [편집기 확장 설치](https://prettier.io/docs/en/editors.html)를 권장드립니다.
- [x] (선택 사항) [EditorConfig](https://editorconfig.org) 편집기 플러그인 사용하기, 프로젝트 내 편집기 인덴트 설정을 two-space 로 고정해줍니다.
- [x] 타입 체크가 통과되었나요? `yarn tsc` 를 실행하고 오류가 있는 구문을 고쳐주세요.
- [x] ESLint 규칙이 모두 다 통과되었나요? `yarn lint` 를 실행해서 오류가 있는지 확인해주세요.

---

## 주요 변경 사항

- CSS 내에서 모든 상대단위(rem)을 절대단위(px)로 변환했습니다.
- 이때 1rem = 16px를 기준으로 변환하였습니다.
